### PR TITLE
Remove LONG data type from Number Types UG section.

### DIFF
--- a/doc/user_guide/oracle_user_guide.md
+++ b/doc/user_guide/oracle_user_guide.md
@@ -166,7 +166,7 @@ The Oracle dialect does not support all capabilities. A complete list can be fou
 
 ### Mapping of Number Types:
 
-`NUMBER`, `NUMBER with precision > 36` and `LONG` are casted to `VARCHAR` to prevent a loss of precision. 
+`NUMBER` and `NUMBER with precision > 36` are casted to `VARCHAR` to prevent a loss of precision.
 
 If you want to return a DECIMAL type for these types you can set the property `ORACLE_CAST_NUMBER_TO_DECIMAL_WITH_PRECISION_AND_SCALE` to `<precision>,<scale>`.
 This will cast values of such types to `DECIMAL(<precision>,<scale>)`.


### PR DESCRIPTION
LONG in Oracle is a legacy **character** data type (see https://docs.oracle.com/database/121/SQLRF/sql_elements001.htm#SQLRF0021).
So it is mapped to VARCHAR not to "prevent a loss of precision".